### PR TITLE
Fix: crash when the url contains $ + number

### DIFF
--- a/Juktaway/src/main/java/net/slash_omega/juktaway/fragment/profile/DescriptionFragment.kt
+++ b/Juktaway/src/main/java/net/slash_omega/juktaway/fragment/profile/DescriptionFragment.kt
@@ -31,8 +31,7 @@ class DescriptionFragment: Fragment() {
             if (!user.description.isNullOrEmpty()) {
                 var descStr = user.description
                 user.entities?.description?.urls?.forEach {
-                    val matcher = Pattern.compile(it.url).matcher(descStr)
-                    descStr = matcher.replaceAll(it.expandedUrl)
+                    descStr = descStr?.replace(it.url, it.expandedUrl)
                 }
                 description.text = descStr
                 description.visibility = View.VISIBLE

--- a/Juktaway/src/main/java/net/slash_omega/juktaway/fragment/profile/DescriptionFragment.kt
+++ b/Juktaway/src/main/java/net/slash_omega/juktaway/fragment/profile/DescriptionFragment.kt
@@ -13,7 +13,6 @@ import net.slash_omega.juktaway.R
 import net.slash_omega.juktaway.util.parseWithClient
 import java.text.SimpleDateFormat
 import java.util.*
-import java.util.regex.Pattern
 
 /**
  * Created on 2018/11/18.
@@ -28,16 +27,10 @@ class DescriptionFragment: Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
         inflater.inflate(R.layout.fragment_profile_description, container, false)?.apply {
-            if (!user.description.isNullOrEmpty()) {
-                var descStr = user.description
-                user.entities?.description?.urls?.forEach {
-                    descStr = descStr?.replace(it.url, it.expandedUrl)
-                }
-                description.text = descStr
-                description.visibility = View.VISIBLE
-            } else {
-                description.visibility = View.GONE
-            }
+            description.visibility = user.description.takeUnless { it.isNullOrEmpty() }?.let { desc ->
+                description.text = user.entities?.description?.urls?.fold(desc) { acc, url -> acc.replace(url.url, url.expandedUrl) }
+                View.VISIBLE
+            } ?: View.GONE
 
             if (!user.location.isNullOrEmpty()) {
                 location.text = user.location

--- a/Juktaway/src/main/java/net/slash_omega/juktaway/util/StatusUtil.kt
+++ b/Juktaway/src/main/java/net/slash_omega/juktaway/util/StatusUtil.kt
@@ -43,7 +43,7 @@ val Status.imageUrls: List<String>
     }
 
 object StatusUtil {
-    private val URL_PATTERN = Pattern.compile("(http://|https://)[\\w.\\-/:#?=&;%~+]+")
+    private val URL_PATTERN = Pattern.compile("(http://|https://)[\\w.\\-/:#?=&;%~+\\$]+")
     private val MENTION_PATTERN = Pattern.compile("@[a-zA-Z0-9_]+")
     @Suppress("SpellCheckingInspection")
     private val HASHTAG_PATTERN = Pattern.compile("#\\S+")
@@ -87,13 +87,11 @@ object StatusUtil {
     fun getExpandedText(status: Status): String {
         var text = status.fullText()
         for (url in status.entities.urls) {
-            val m = Pattern.compile(url.url).matcher(text)
-            text = m.replaceAll(url.expandedUrl)
+            text = text.replace(url.url, url.expandedUrl)
         }
 
         for (media in status.entities.media) {
-            val m = Pattern.compile(media.url).matcher(text)
-            text = m.replaceAll(media.expandedUrl)
+            text = text.replace(media.url, media.expandedUrl)
         }
         return text
     }

--- a/Juktaway/src/main/java/net/slash_omega/juktaway/util/StatusUtil.kt
+++ b/Juktaway/src/main/java/net/slash_omega/juktaway/util/StatusUtil.kt
@@ -43,7 +43,7 @@ val Status.imageUrls: List<String>
     }
 
 object StatusUtil {
-    private val URL_PATTERN = Pattern.compile("(http://|https://)[\\w.\\-/:#?=&;%~+\\$]+")
+    private val URL_PATTERN = Pattern.compile("(http://|https://)[\\w.\\-/:#?=&;%~+$]+")
     private val MENTION_PATTERN = Pattern.compile("@[a-zA-Z0-9_]+")
     @Suppress("SpellCheckingInspection")
     private val HASHTAG_PATTERN = Pattern.compile("#\\S+")
@@ -84,17 +84,10 @@ object StatusUtil {
      * @param status ツイート
      * @return 短縮URLを展開したツイート本文
      */
-    fun getExpandedText(status: Status): String {
-        var text = status.fullText()
-        for (url in status.entities.urls) {
-            text = text.replace(url.url, url.expandedUrl)
-        }
-
-        for (media in status.entities.media) {
-            text = text.replace(media.url, media.expandedUrl)
-        }
-        return text
-    }
+    fun getExpandedText(status: Status): String
+            = status.fullText()
+                    .let { status.entities.urls.fold(it) { acc, url -> acc.replace(url.url, url.expandedUrl) } }
+                    .let { status.entities.media.fold(it) { acc, media -> acc.replace(media.url, media.expandedUrl) } }
 
     /**
      * ツイートに含まれる画像のURLをすべて取得する

--- a/Juktaway/src/main/java/net/slash_omega/juktaway/util/TwitterUtil.kt
+++ b/Juktaway/src/main/java/net/slash_omega/juktaway/util/TwitterUtil.kt
@@ -21,7 +21,7 @@ inline fun <reified M: PenicillinModel> JsonElement.parseWithClient() = parseMod
 
 object TwitterUtil {
 
-    private val URL_PATTERN = Pattern.compile("(http://|https://)[\\w.\\-/:#?=&;%~+]+")
+    private val URL_PATTERN = Pattern.compile("(http://|https://)[\\w.\\-/:#?=&;%~+\\$]+")
     private const val BATTERY_ROW_LEVEL = 14
 
     /**

--- a/Juktaway/src/main/java/net/slash_omega/juktaway/util/TwitterUtil.kt
+++ b/Juktaway/src/main/java/net/slash_omega/juktaway/util/TwitterUtil.kt
@@ -21,7 +21,7 @@ inline fun <reified M: PenicillinModel> JsonElement.parseWithClient() = parseMod
 
 object TwitterUtil {
 
-    private val URL_PATTERN = Pattern.compile("(http://|https://)[\\w.\\-/:#?=&;%~+\\$]+")
+    private val URL_PATTERN = Pattern.compile("(http://|https://)[\\w.\\-/:#?=&;%~+$]+")
     private const val BATTERY_ROW_LEVEL = 14
 
     /**


### PR DESCRIPTION
ツイート内などの短縮 URL の展開後のものに $ と数字の組み合わせが入っていると，`replaceAll` に展開後 URL が入った際に当該部分が後方参照として扱われるために，`ArrayIndexOutOfBoundsException`でクラッシュするようです(Justaway 時代からの不具合)。この PR はそれを解消するものです。

URL 例: https://www.abc.net.au/news/2019-03-25/kenyan-school-teacher-wins-$1-million-teaching-prize/10935276
ツイート例: https://twitter.com/abcnews/status/1109977957479538688